### PR TITLE
update Nobara Welcome GUI

### DIFF
--- a/nobara-welcome/39/nobara-welcome/etc/nobara/scripts/nobara-welcome/nobara-welcome.py
+++ b/nobara-welcome/39/nobara-welcome/etc/nobara/scripts/nobara-welcome/nobara-welcome.py
@@ -297,7 +297,7 @@ class Application:
         subprocess.Popen(["/etc/nobara/scripts/nobara-welcome/nvidia.sh"], shell=True)
     ### ROCm ###
     def enter_rocm(self, widget):
-        subprocess.Popen(["/usr/lib/pika/welcome/xdg-terminal '/usr/lib/pika/welcome/pkcon-install.sh install nobara-rocm-meta'"], shell=True)
+        subprocess.Popen(["/etc/nobara/scripts/nobara-welcome/xdg-terminal '/etc/nobara/scripts/nobara-welcome/pkcon-install.sh install rocm-meta'"], shell=True)
     ### XONE ###
     def enter_xone(self, widget):
         subprocess.Popen(["/usr/bin/nobara-controller-config"], shell=True)

--- a/nobara-welcome/39/nobara-welcome/etc/nobara/scripts/nobara-welcome/nobara-welcome.py
+++ b/nobara-welcome/39/nobara-welcome/etc/nobara/scripts/nobara-welcome/nobara-welcome.py
@@ -168,6 +168,7 @@ class Application:
             ge_gitlab_logo = self.builder.get_object("ge_gitlab_logo")
             ge_github_logo = self.builder.get_object("ge_github_logo")
             cosmo_github_logo = self.builder.get_object("cosmo_github_logo")
+            nobara_project_logo = self.builder.get_object("nobara_project_logo")
             
             ###
             
@@ -227,6 +228,7 @@ class Application:
             ge_gitlab_logo = self.builder.get_object("ge_gitlab_logo")
             ge_github_logo = self.builder.get_object("ge_github_logo")
             cosmo_github_logo = self.builder.get_object("cosmo_github_logo")
+            nobara_project_logo = self.builder.get_object("nobara_project_logo")
             
             update_logo.set_from_icon_name("system-software-update", 80)
             nvidia_logo.set_from_icon_name("nvidia", 80)
@@ -262,6 +264,7 @@ class Application:
             ge_gitlab_logo.set_from_icon_name("gitlab", 80)
             ge_github_logo.set_from_icon_name("github", 80)
             cosmo_github_logo.set_from_icon_name("github", 80)
+            nobara_project_logo.set_from_icon_name("fedora-logo-icon", 80)
         pass
         
     def on_sidebar_btn_pressed(self, widget):
@@ -365,6 +368,9 @@ class Application:
     ### COSMO GITHUB ###
     def enter_cosmo_github(self, widget):
         subprocess.Popen(["xdg-open https://github.com/CosmicFusion"], shell=True)
+    ### NOBARA GITHUB ###
+    def enter_nobara_github(self, widget):
+        subprocess.Popen(["xdg-open https://github.com/Nobara-Project"], shell=True)
     ###############################################################
     #### Install Window ####
     

--- a/nobara-welcome/39/nobara-welcome/etc/nobara/scripts/nobara-welcome/nobara-welcome.ui
+++ b/nobara-welcome/39/nobara-welcome/etc/nobara/scripts/nobara-welcome/nobara-welcome.ui
@@ -804,6 +804,7 @@ communities called "servers".</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox" id="rocm_box">
+                            <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="spacing">10</property>
                             <child>

--- a/nobara-welcome/39/nobara-welcome/etc/nobara/scripts/nobara-welcome/nobara-welcome.ui
+++ b/nobara-welcome/39/nobara-welcome/etc/nobara/scripts/nobara-welcome/nobara-welcome.ui
@@ -1058,7 +1058,6 @@ Install fixups to allow DaVinci Resolve to run.
                             <property name="position">3</property>
                           </packing>
                         </child>
-
                         <child>
                           <object class="GtkBox" id="steamfix_box">
                             <property name="visible">True</property>
@@ -1122,7 +1121,6 @@ Install fixups to allow a few native linux Steam games to work (see https://gist
                             <property name="position">3</property>
                           </packing>
                         </child>
-
                       </object>
                     </child>
                   </object>
@@ -1956,6 +1954,67 @@ Install fixups to allow a few native linux Steam games to work (see https://gist
                             <property name="fill">True</property>
                             <property name="padding">4</property>
                             <property name="position">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="nobara_github_box">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="spacing">10</property>
+                            <child>
+                              <object class="GtkImage" id="nobara_project_logo">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="margin-start">10</property>
+                                <property name="pixel-size">80</property>
+                                <property name="icon-name">fedora-logo-icon</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="nobara_github_text">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">&lt;big&gt;Contribute code to Nobara Project's &lt;b&gt;Github&lt;/b&gt;&lt;/big&gt;</property>
+                                <property name="use-markup">True</property>
+                                <property name="wrap">True</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="nobara_project_button">
+                                <property name="label" translatable="yes">Open</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="margin-end">10</property>
+                                <property name="margin-top">10</property>
+                                <property name="margin-bottom">10</property>
+                                <signal name="pressed" handler="enter_nobara_github" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">4</property>
+                            <property name="position">6</property>
                           </packing>
                         </child>
                       </object>


### PR DESCRIPTION
- adds Nobara Project Github to Contribute section
- fixes ROCm install to match Nobara packaging instead of PikaOS and unhides the install shortcut