### PR TITLE
add support for Sound Blaster sound cards to driver-db and some minor core package tweaks

### DIFF
--- a/create-tarballs.sh
+++ b/create-tarballs.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 tar -cvzf kde-nobara.tar.gz kde-nobara
+tar -cvzf nobara-drivers-gtk4.tar.gz nobara-drivers-gtk4
 tar -cvzf nobara-nvidia-wizard.tar.gz nobara-nvidia-wizard
 tar -cvzf nobara-resolve-runtime.tar.gz nobara-resolve-runtime
 tar -cvzf nobara-logos.tar.gz nobara-logos
+tar -cvzf nobara-welcome-gtk4.tar.gz nobara-welcome-gtk4
 
 cd nobara-welcome/38
 tar -cvzf nobara-welcome-38.tar.gz nobara-welcome

--- a/nobara-drivers-gtk4/data/generate_package_info.sh
+++ b/nobara-drivers-gtk4/data/generate_package_info.sh
@@ -3,9 +3,9 @@
 if [[ $1 == "version" ]]
 then
 	#apt-cache show $2 | grep Version: | cut -d":" -f2 | head -n1
-	dnf info available $2 | grep Version | cut -d":" -f2 | head -n1
+	dnf info $2 | grep Version | cut -d":" -f2 | head -n1
 elif [[ $1 == "description" ]]
 then
 	#apt-cache show $2 | grep 'Description*' | cut -d":" -f2 | head -n1
-	dnf info available $2 | grep Description | cut -d":" -f2 | head -n1
+	dnf info $2 | grep Description | cut -d":" -f2 | head -n1
 fi

--- a/nobara-drivers-gtk4/driver-db.json
+++ b/nobara-drivers-gtk4/driver-db.json
@@ -28,7 +28,7 @@
       "id": 3,
       "driver": "alsa-firmware",
       "icon": "speaker",
-      "experimental": true,
+      "experimental": false,
       "removable": true,
       "detection": "lspci -D | grep -iE 'Audio' | grep -i 'Sound Blaster'"
     }

--- a/nobara-drivers-gtk4/driver-db.json
+++ b/nobara-drivers-gtk4/driver-db.json
@@ -23,6 +23,14 @@
       "experimental": false,
       "removable": true,
       "detection": "lspci -D | grep -iE 'VGA|3D' | grep -i nvidia"
+    },
+    {
+      "id": 3,
+      "driver": "alsa-firmware",
+      "icon": "speaker",
+      "experimental": true,
+      "removable": true,
+      "detection": "lspci -D | grep -iE 'Audio' | grep -i 'Sound Blaster'"
     }
   ]
 }


### PR DESCRIPTION
LINKED WITH https://github.com/Nobara-Project/rpm-sources/pull/27

- adds support for detecting Sound Blaster sound cards and installing the required `alsa-firmware` for them. this fixes audio output for many Sound Blaster models, including my own AE-5 Plus
- changes `generate_package_info.sh` to use `dnf info` instead of `dnf info available`. this avoids a state where, after being installed, drivers from a Fedora repo like `alsa-firmware`  have this output with `dnf info available $2 (or the exact package name for testing from terminal)`: `Error: No matching Packages to list`. when this happens, no description is provided for packages like `alsa-firmware` in the driver manager UI.
- add the new gtk4 app versions to the tarball script

in addition, perhaps we should include `alsa-firmware` on the kickstart. it's 11Mb installed. for existing users, this db entry may be helpful regardless.