### PR TITLE
fixup descriptions and expand nobara-drivers-gtk4

### DIFF
--- a/nobara-drivers-gtk4/data/generate_package_info.sh
+++ b/nobara-drivers-gtk4/data/generate_package_info.sh
@@ -7,5 +7,5 @@ then
 elif [[ $1 == "description" ]]
 then
 	#apt-cache show $2 | grep 'Description*' | cut -d":" -f2 | head -n1
-	dnf info $2 | grep Description | cut -d":" -f2 | head -n1
+	dnf info $2 | sed -n '/Description/,/^$/p' | awk 'NR==1,/^$/ {if (/^$/ && printed) exit; if (NF) printed=1; if (NR==1) sub(/Description *: */, ""); else sub(/^ *: */, ""); print}'
 fi

--- a/nobara-drivers-gtk4/data/modify-driver.sh
+++ b/nobara-drivers-gtk4/data/modify-driver.sh
@@ -51,7 +51,7 @@ elif [[ "$1" = "xone" ]]
 then
 	if rpm -q xone
 	then
-		pkcon remove -y lpf-xone-firmware xone xpadneo xone-firmware
+		dnf remove -y lpf-xone-firmware xone xpadneo xone-firmware
 	else
 		dnf install -y "dnf5-command(builddep)"
 		usermod -aG pkg-build $USER && dnf4 install -y lpf-xone-firmware xone xpadneo && dnf4 remove -y xone-firmware
@@ -59,22 +59,23 @@ then
 		sudo -i -u pkg-build lpf update xone-firmware
 	fi
 	exit 0
+# Special override for asusctl
 elif [[ "$1" = "asusctl" ]]
 then
 	if rpm -q asusctl
 	then
-		pkcon remove -y asusctl asusctl-rog-gui
+		dnf remove -y asusctl asusctl-rog-gui
 	else
-		pkcon install -y asusctl asusctl-rog-gui
+		dnf install -y asusctl asusctl-rog-gui
 	fi
 	exit 0
 # Standard case
 else
 	if rpm -q "$1"
 	then
-		pkcon remove -y "$1"
+		dnf remove -y "$1"
 	else
-		pkcon install -y "$1"
+		dnf install -y "$1"
 	fi
 	exit 0
 fi

--- a/nobara-drivers-gtk4/data/modify-driver.sh
+++ b/nobara-drivers-gtk4/data/modify-driver.sh
@@ -59,6 +59,15 @@ then
 		sudo -i -u pkg-build lpf update xone-firmware
 	fi
 	exit 0
+elif [[ "$1" = "asusctl" ]]
+then
+	if rpm -q asusctl
+	then
+		pkcon remove -y asusctl asusctl-rog-gui
+	else
+		pkcon install -y asusctl asusctl-rog-gui
+	fi
+	exit 0
 # Standard case
 else
 	if rpm -q "$1"

--- a/nobara-drivers-gtk4/driver-db.json
+++ b/nobara-drivers-gtk4/driver-db.json
@@ -35,7 +35,7 @@
     {
       "id": 4,
       "driver": "asusctl",
-      "icon": "fan",
+      "icon": "preferences-desktop",
       "experimental": false,
       "removable": true,
       "detection": "cat /sys/devices/virtual/dmi/id/product_name | grep -i 'ROG'"

--- a/nobara-drivers-gtk4/driver-db.json
+++ b/nobara-drivers-gtk4/driver-db.json
@@ -31,6 +31,14 @@
       "experimental": false,
       "removable": true,
       "detection": "lspci -D | grep -iE 'Audio' | grep -i 'Sound Blaster'"
+    },
+    {
+      "id": 4,
+      "driver": "asusctl",
+      "icon": "fan",
+      "experimental": false,
+      "removable": true,
+      "detection": "cat /sys/devices/virtual/dmi/id/product_name | grep -i 'ROG'"
     }
   ]
 }


### PR DESCRIPTION
this refactors us away from the inconsistent use of dnf and pkcon in modify-driver.sh to prefer dnf use.

the edit to genereate_package_info.sh lets us print the description blurb in a clean formatting style to the driver manager window.

finally, i'm adding in an entry that searches for "ROG" as a device ID and offers to install asusctl and asusctl-rog-gui if it detects this. since asusctl focuses on gaming laptops, I figured limitiing it to ROG model names should work.