### PR TITLE
kde-nobara: Delete theme.conf.user

### DIFF
--- a/kde-nobara/usr/share/sddm/themes/nobara/theme.conf.user
+++ b/kde-nobara/usr/share/sddm/themes/nobara/theme.conf.user
@@ -1,3 +1,0 @@
-[General]
-type=image
-background=/usr/share/wallpapers/nobara-40-2.png


### PR DESCRIPTION
The file is auto-generated by KDE when you set a custom SDDM wallpaper, and the wallpaper itself gets copied over to `/usr/share/sddm/themes/nobara/`

Including this file with a path other than local to the folder it is present, for some reason makes the system delete the file it's pointing at.

Either way, this file isn't needed for the theme to function properly.