### PR TITLE
Add support for broadcom-wl

### DIFF
--- a/nobara-drivers-gtk4/driver-db.json
+++ b/nobara-drivers-gtk4/driver-db.json
@@ -39,6 +39,14 @@
       "experimental": false,
       "removable": true,
       "detection": "cat /sys/devices/virtual/dmi/id/product_name | grep -i 'ROG'"
+    },
+    {
+      "id": 5,
+      "driver": "broadcom-wl",
+      "icon": "network-wireless",
+      "experimental": false,
+      "removable": true,
+      "detection": "lspci -D | grep -iE 'wireless' | grep -i 'broadcom'"
     }
   ]
 }


### PR DESCRIPTION
Fixes #15 by adding the broadcom-wl driver to the driver manager. This might not be necessary for all models captured by the grep.



More advanced detection could be possible via `lspci -vnn -d 14e4` (https://wiki.archlinux.org/title/Broadcom_wireless) and https://wireless.docs.kernel.org/en/latest/en/users/drivers/brcm80211.html#unsupported-chips but would require keeping up to date and might be overkill.

![Screenshot_20241109_201130](https://github.com/user-attachments/assets/700a7d19-74e1-4d9d-8263-012b3d65cf88)
(adapter in screenshot is not broadcom, used for testing purposes)

lspci examples

```
0b:00.0 Network controller: Broadcom Corporation BCM4312 802.11b/g (rev 01) <- older model, supported by b43
03:00.0 Network controller [0280]: Broadcom Inc. and subsidiaries BCM43602 802.11ac Wireless LAN SoC [14e4:43ba] (rev 01)
03:00.0 Network controller: Broadcom Inc. and subsidiaries BCM4360 802.11ac Wireless Network Adapter (rev 03) 
---

This pull request includes an update to the `driver-db.json` file in the `nobara-drivers-gtk4` directory. The change adds a new driver entry for Broadcom wireless devices.