### PR TITLE
make automounting UUID based to ensure stability across reboots

### DIFF
--- a/nobara-updater/src/nobara_tweak_tool.py
+++ b/nobara-updater/src/nobara_tweak_tool.py
@@ -304,7 +304,7 @@ def main():
     tk.Label(partitions_frame, text=mount_note4).pack(anchor='w')
 
     # Add note about UUIDs
-    mount_note4 = f"Only device paths starting with /dev/disk/by-uuid/ are supported for stabiliyt across reboots."
+    mount_note4 = f"Only device paths starting with /dev/disk/by-uuid/ are supported for stability across reboots."
     tk.Label(partitions_frame, text=mount_note4).pack(anchor='w')
 
     # Add note about mount location


### PR DESCRIPTION
this belongs to an identical PR to nobara-automount in the nobara rpm-sources repo https://github.com/Nobara-Project/rpm-sources/pull/114.

As discussed on discord, the only way to ensure links to automounted drives do not break across reboots (as PCIe enumeration is not stable and hence nvme drives can change numbers arbitrarily) is to use UUIDs.

This change facilitates that. Also it cleans up the conf file in case non-uuid paths are in there and adds a hint in the UI about what is supported.