### PR TITLE
Add error handling to flatpak_system_updates getter

### DIFF
--- a/nobara-updater/src/nobara_sync.py
+++ b/nobara-updater/src/nobara_sync.py
@@ -563,6 +563,7 @@ class fp_system_installation_list(object):
             try:
                 flatpak_system_updates = self.system_installation.list_installed_refs_for_update(None)
             except gi.repository.GLib.GError as e:
+                # Expected, see #43
                 logger.error(e)
             except:
                 raise

--- a/nobara-updater/src/nobara_sync.py
+++ b/nobara-updater/src/nobara_sync.py
@@ -564,6 +564,8 @@ class fp_system_installation_list(object):
                 flatpak_system_updates = self.system_installation.list_installed_refs_for_update(None)
             except gi.repository.GLib.GError as e:
                 logger.error(e)
+            except:
+                raise
             else:
                 error = False
         return flatpak_system_updates

--- a/nobara-updater/src/nobara_sync.py
+++ b/nobara-updater/src/nobara_sync.py
@@ -527,8 +527,8 @@ def fp_get_system_updates() -> list[Flatpak.Ref] | None:
     # Get our flatpak updates
     system_installation = Flatpak.Installation.new_system(None)
     with fp_system_installation_list(system_installation) as flatpak_sys_updates:
-        if flatpak_system_updates != []:
-            return flatpak_system_updates
+        if flatpak_sys_updates != []:
+            return flatpak_sys_updates
         return []
 
 
@@ -557,6 +557,7 @@ class fp_system_installation_list(object):
 
 
     def __enter__(self):
+        flatpak_system_updates = None
         error = True # No do-while in Python so init to true to run loop once
         while not error:
             try:

--- a/nobara-updater/src/nobara_sync.py
+++ b/nobara-updater/src/nobara_sync.py
@@ -525,8 +525,7 @@ def check_updates(return_texts: bool = False) -> None | tuple[str | None, str | 
 
 def fp_get_system_updates() -> list[Flatpak.Ref] | None:
     # Get our flatpak updates
-    system_installation = Flatpak.Installation.new_system(None)
-    with fp_system_installation_list(system_installation) as flatpak_sys_updates:
+    with fp_system_installation_list(Flatpak.Installation.new_system(None)) as flatpak_sys_updates:
         if flatpak_sys_updates != []:
             return flatpak_sys_updates
         return []
@@ -549,6 +548,7 @@ def install_system_flatpak_updates() -> None:
                     logger.error("Error updating %s: %s", ref.get_appdata_name(), e)
             transaction.run()
             logger.info("Flatpak System Updates complete!")
+    del system_installation
 
 class fp_system_installation_list(object):
     # Generates flatpak_system_updates for other functions with error handling

--- a/nobara-updater/src/nobara_sync.py
+++ b/nobara-updater/src/nobara_sync.py
@@ -559,7 +559,7 @@ class fp_system_installation_list(object):
     def __enter__(self):
         flatpak_system_updates = None
         error = True # No do-while in Python so init to true to run loop once
-        while not error:
+        while error:
             try:
                 flatpak_system_updates = self.system_installation.list_installed_refs_for_update(None)
             except gi.repository.GLib.GError as e:

--- a/nobara-updater/src/nobara_sync.py
+++ b/nobara-updater/src/nobara_sync.py
@@ -526,31 +526,50 @@ def check_updates(return_texts: bool = False) -> None | tuple[str | None, str | 
 def fp_get_system_updates() -> list[Flatpak.Ref] | None:
     # Get our flatpak updates
     system_installation = Flatpak.Installation.new_system(None)
-    flatpak_system_updates = system_installation.list_installed_refs_for_update(None)
-    del system_installation
-    if flatpak_system_updates != []:
-        return flatpak_system_updates
-    return []
+    with fp_system_installation_list(system_installation) as flatpak_sys_updates:
+        if flatpak_system_updates != []:
+            return flatpak_system_updates
+        return []
 
 
 def install_system_flatpak_updates() -> None:
     # System installation updates
     system_installation = Flatpak.Installation.new_system(None)
-    flatpak_sys_updates = system_installation.list_installed_refs_for_update(None)
-    if flatpak_sys_updates is not None:
-        transaction = Flatpak.Transaction.new_for_installation(system_installation)
-        for ref in flatpak_sys_updates:
-            logger.info(
-                "Updating %s for system installation...", ref.get_appdata_name()
-            )
+    with fp_system_installation_list(system_installation) as flatpak_sys_updates:
+        if flatpak_sys_updates is not None:
+            transaction = Flatpak.Transaction.new_for_installation(system_installation)
+            for ref in flatpak_sys_updates:
+                logger.info(
+                    "Updating %s for system installation...", ref.get_appdata_name()
+                )
+                try:
+                    # Perform the update
+                    transaction.add_update(ref.format_ref(), None, None)
+                except Exception as e:
+                    logger.error("Error updating %s: %s", ref.get_appdata_name(), e)
+            transaction.run()
+            logger.info("Flatpak System Updates complete!")
+
+class fp_system_installation_list(object):
+    # Generates flatpak_system_updates for other functions with error handling
+    def __init__(self, system_installation):
+        self.system_installation = system_installation
+
+
+    def __enter__(self):
+        error = True # No do-while in Python so init to true to run loop once
+        while not error:
             try:
-                # Perform the update
-                transaction.add_update(ref.format_ref(), None, None)
-            except Exception as e:
-                logger.error("Error updating %s: %s", ref.get_appdata_name(), e)
-        transaction.run()
-        logger.info("Flatpak System Updates complete!")
-    del system_installation
+                flatpak_system_updates = self.system_installation.list_installed_refs_for_update(None)
+            except gi.repository.GLib.GError as e:
+                logger.error(e)
+            else:
+                error = False
+        return flatpak_system_updates
+    
+
+    def __exit__(self, *args):
+        del self.system_installation
 
 def button_ensure_sensitivity(
     widget: Gtk.Widget, desired_state: bool


### PR DESCRIPTION
Fixes #43.

The only "new" code is the block:
```
        error = True # No do-while in Python so init to true to run loop once
        while not error:
            try:
                flatpak_system_updates = self.system_installation.list_installed_refs_for_update(None)
            except gi.repository.GLib.GError as e:
                logger.error(e)
            else:
                error = False
```

I ended up using the with statement to reduce repeated code. However, you may find it simpler to either:
- Copy paste the while loop in the two places `flatpak_system_updates` is used
- Use the `@contextmanager` decorator from `contextlib` to use a "function" instead of a "class"

I also ended up making the naming more consistent between the two functions that used the `flatpak_system_updates` variable.

You may also want to add some sort of timeout to the loop to prevent infinite blocking (e.g. if the user runs `nobara-sync` with no internet I feel like the error would not go away)

Need to verify that `del self.system_installation` actually works and doesn't introduce a memory leak.

No code quality guideline was provided so I used my rusty PEP-8 muscle memory. Seems to all look close enough to the existing code.

Also, complete disclaimer, this code is untested as I do not have a build environment nor can I reliably reproduce the error. Reading through, unless stated above I don't see any issues but the lack of testing is still a concern.