### PR TITLE
quirks.py: stop treating rc 100 as an error

### DIFF
--- a/nobara-updater/src/quirks.py
+++ b/nobara-updater/src/quirks.py
@@ -625,11 +625,15 @@ class QuirkFixup:
         def check_update():
             try:
                 # Run the dnf check-update command and filter for plasma-workspace
-                result = subprocess.run(['dnf', 'check-update'], capture_output=True, text=True, check=True)
+                result = subprocess.run(['dnf', 'check-update'], capture_output=True, text=True, check=False)
                 # Use Python's string filtering instead of piping in the shell
-                if 'plasma-workspace' in result.stdout:
-                    return True
+                if result.returncode in [0, 100]:
+                    if 'plasma-workspace' in result.stdout:
+                        return True
+                    return False
+                self.logger.error(f"DNF error (code {result.returncode}): {result.stderr}")
                 return False
+                
             except subprocess.CalledProcessError as e:
                 print(f"Failed to run dnf command: {e}")
                 return False


### PR DESCRIPTION
When the clear plasmashell cache quirk runs and there are pending updates, the `check-update` command will return an exit code of 100.

This is not an error, stop checking explicitly for exit code 0, and treat both 0 and 100 as success.