### PR TITLE
Fix automount XDG_DESKTOP_DIR handling, repair-loop hang, and silent upgrade transactions

### DIFF
--- a/nobara-automount/data/nobara-automount/usr/libexec/nobara-automount
+++ b/nobara-automount/data/nobara-automount/usr/libexec/nobara-automount
@@ -6,19 +6,35 @@ log() { echo "[nobara-automount] $*"; }
 # Resolve a user's XDG_DESKTOP_DIR from ~/.config/user-dirs.dirs, falling
 # back to "$home/Desktop" if unset/missing. Parsed as plain text (not
 # sourced) since this runs as root against a file the target user controls.
+#
+# The resolved path is used for root-privileged installs and deletes of
+# .desktop files, so a raw value from that file can't be trusted as-is:
+# it's canonicalized (resolving any "..") and required to already exist
+# and be owned by the target user before it's used, otherwise a value
+# like XDG_DESKTOP_DIR="/etc" or "$HOME/../../etc" could point the script
+# at an arbitrary root-owned/system directory. Anything that fails those
+# checks falls back to "$home/Desktop".
 resolve_desktop_dir() {
-  local home="$1"
+  local home="$1" owner="$2"
   local conf="${home}/.config/user-dirs.dirs"
-  local raw="" dir=""
+  local raw="" candidate="" dir=""
   if [[ -f "$conf" ]]; then
     raw="$(grep -m1 '^XDG_DESKTOP_DIR=' "$conf" 2>/dev/null | cut -d= -f2-)"
     raw="${raw%\"}"
     raw="${raw#\"}"
     case "$raw" in
-      \$HOME/*) dir="${home}/${raw#\$HOME/}" ;;
-      \$HOME) dir="${home}" ;;
-      /*) dir="$raw" ;;
+      \$HOME/*) candidate="${home}/${raw#\$HOME/}" ;;
+      \$HOME) candidate="${home}" ;;
+      /*) candidate="$raw" ;;
     esac
+    if [[ -n "$candidate" ]]; then
+      local real real_owner
+      real="$(realpath -m -- "$candidate" 2>/dev/null)" || real=""
+      if [[ -n "$real" && -d "$real" ]]; then
+        real_owner="$(stat -c '%U' -- "$real" 2>/dev/null)" || real_owner=""
+        [[ "$real_owner" == "$owner" ]] && dir="$real"
+      fi
+    fi
   fi
   [[ -z "$dir" ]] && dir="${home}/Desktop"
   printf '%s\n' "$dir"
@@ -82,7 +98,7 @@ if [[ ${USER:-} != "liveuser" ]]; then
       if ! grep -Fq "$UUID_FILTER" /etc/nobara/automount/desktop_shortcuts.conf; then
         log "Skipping desktop shortcut creation for $mp not in desktop_shortcuts.conf"
         [[ -z "$UUID_FILTER" ]] && exit 0
-        desktop_dir="$(resolve_desktop_dir "$(getent passwd "$rwuser" | cut -d: -f6)")"
+        desktop_dir="$(resolve_desktop_dir "$(getent passwd "$rwuser" | cut -d: -f6)" "$rwuser")"
 
         # loop over all .desktop files and check contents for UUID_FILTER
         for f in "$desktop_dir"/*.desktop; do
@@ -95,7 +111,7 @@ if [[ ${USER:-} != "liveuser" ]]; then
     else
       log "desktop_shortcut.conf not found; skipping desktop shortcut creation for $mp"
       [[ -z "$UUID_FILTER" ]] && exit 0
-      desktop_dir="$(resolve_desktop_dir "$(getent passwd "$rwuser" | cut -d: -f6)")"
+      desktop_dir="$(resolve_desktop_dir "$(getent passwd "$rwuser" | cut -d: -f6)" "$rwuser")"
 
       # loop over all .desktop files and check contents for UUID_FILTER
       for f in "$desktop_dir"/*.desktop; do
@@ -214,7 +230,7 @@ if [[ ${USER:-} != "liveuser" ]]; then
         [[ -n "$label" ]] && pretty="$label"
 
         user_home="$(getent passwd "$rwuser" | cut -d: -f6)"
-        desktop_dir="$(resolve_desktop_dir "$user_home")"
+        desktop_dir="$(resolve_desktop_dir "$user_home" "$rwuser")"
         mp="/run/media/${rwuser}/${uuid}"
         url="file://${mp}"
         icon_path="${desktop_dir}/${pretty}.desktop"

--- a/nobara-automount/data/nobara-automount/usr/libexec/nobara-automount
+++ b/nobara-automount/data/nobara-automount/usr/libexec/nobara-automount
@@ -3,6 +3,27 @@ set -euo pipefail
 
 log() { echo "[nobara-automount] $*"; }
 
+# Resolve a user's XDG_DESKTOP_DIR from ~/.config/user-dirs.dirs, falling
+# back to "$home/Desktop" if unset/missing. Parsed as plain text (not
+# sourced) since this runs as root against a file the target user controls.
+resolve_desktop_dir() {
+  local home="$1"
+  local conf="${home}/.config/user-dirs.dirs"
+  local raw="" dir=""
+  if [[ -f "$conf" ]]; then
+    raw="$(grep -m1 '^XDG_DESKTOP_DIR=' "$conf" 2>/dev/null | cut -d= -f2-)"
+    raw="${raw%\"}"
+    raw="${raw#\"}"
+    case "$raw" in
+      \$HOME/*) dir="${home}/${raw#\$HOME/}" ;;
+      \$HOME) dir="${home}" ;;
+      /*) dir="$raw" ;;
+    esac
+  fi
+  [[ -z "$dir" ]] && dir="${home}/Desktop"
+  printf '%s\n' "$dir"
+}
+
 if [[ ${USER:-} != "liveuser" ]]; then
   if [[ $EUID -ne 0 ]]; then
     if ! id -nG "${USER}" | grep -qw wheel; then
@@ -61,7 +82,7 @@ if [[ ${USER:-} != "liveuser" ]]; then
       if ! grep -Fq "$UUID_FILTER" /etc/nobara/automount/desktop_shortcuts.conf; then
         log "Skipping desktop shortcut creation for $mp not in desktop_shortcuts.conf"
         [[ -z "$UUID_FILTER" ]] && exit 0
-        desktop_dir="$(getent passwd "$rwuser" | cut -d: -f6)/Desktop"
+        desktop_dir="$(resolve_desktop_dir "$(getent passwd "$rwuser" | cut -d: -f6)")"
 
         # loop over all .desktop files and check contents for UUID_FILTER
         for f in "$desktop_dir"/*.desktop; do
@@ -74,7 +95,7 @@ if [[ ${USER:-} != "liveuser" ]]; then
     else
       log "desktop_shortcut.conf not found; skipping desktop shortcut creation for $mp"
       [[ -z "$UUID_FILTER" ]] && exit 0
-      desktop_dir="$(getent passwd "$rwuser" | cut -d: -f6)/Desktop"
+      desktop_dir="$(resolve_desktop_dir "$(getent passwd "$rwuser" | cut -d: -f6)")"
 
       # loop over all .desktop files and check contents for UUID_FILTER
       for f in "$desktop_dir"/*.desktop; do
@@ -193,7 +214,7 @@ if [[ ${USER:-} != "liveuser" ]]; then
         [[ -n "$label" ]] && pretty="$label"
 
         user_home="$(getent passwd "$rwuser" | cut -d: -f6)"
-        desktop_dir="${user_home}/Desktop"
+        desktop_dir="$(resolve_desktop_dir "$user_home")"
         mp="/run/media/${rwuser}/${uuid}"
         url="file://${mp}"
         icon_path="${desktop_dir}/${pretty}.desktop"

--- a/nobara-updater/src/dnf.py
+++ b/nobara-updater/src/dnf.py
@@ -298,6 +298,50 @@ def _log_transaction_packages(transaction, logger: logging.Logger) -> None:
         logger.info("    (%s/%s) %s %s", index, total, action, package.get_nevra())
 
 
+class _UpgradeTransactionCallbacks(dnf5_rpm.TransactionCallbacks):
+    """Heartbeat logging for transaction.run().
+
+    Without this, an rpm transaction reports nothing for its entire
+    duration -- no percentage, no package names, no heartbeat -- which on
+    a major-version upgrade can mean 20-40 minutes of total silence with
+    no way to tell a working transaction from a hung one. That silence is
+    exactly what has led users to kill an apparently-frozen upgrade
+    mid-transaction, which can leave the system with thousands of
+    duplicate/orphaned packages that a re-run cannot repair.
+    """
+
+    def __init__(self, logger: logging.Logger, total_packages: int) -> None:
+        super().__init__()
+        self.logger = logger
+        self.total_packages = total_packages
+
+    def transaction_start(self, total: int) -> None:
+        self.logger.info("Preparing transaction (%s items)...", total)
+
+    def elem_progress(self, item, amount: int, total: int) -> None:
+        action = {
+            dnf5_trans.TransactionItemAction_INSTALL: "Installing",
+            dnf5_trans.TransactionItemAction_UPGRADE: "Upgrading",
+            dnf5_trans.TransactionItemAction_DOWNGRADE: "Downgrading",
+            dnf5_trans.TransactionItemAction_REINSTALL: "Reinstalling",
+            dnf5_trans.TransactionItemAction_REMOVE: "Removing",
+            dnf5_trans.TransactionItemAction_REPLACED: "Replacing",
+        }.get(item.get_action(), "Processing")
+        self.logger.info(
+            "    (%s/%s) %s %s", amount + 1, total, action, item.get_package().get_nevra()
+        )
+
+    def script_start(self, item, nevra, type) -> None:
+        self.logger.info(
+            "    Running %s scriptlet for %s...", self.script_type_to_string(type), nevra
+        )
+
+    def script_error(self, item, nevra, type, return_code: int) -> None:
+        self.logger.warning(
+            "    Scriptlet for %s exited with code %s", nevra, return_code
+        )
+
+
 def run_system_upgrade_transaction(logger: logging.Logger | None = None) -> bool:
     tx_logger = logger if logger is not None else logging.getLogger()
     base = dnf5_base.Base()
@@ -343,6 +387,11 @@ def run_system_upgrade_transaction(logger: logging.Logger | None = None) -> bool
         transaction.download()
 
         tx_logger.info("Running transaction...")
+        transaction.set_callbacks(
+            dnf5_rpm.TransactionCallbacksUniquePtr(
+                _UpgradeTransactionCallbacks(tx_logger, transaction.get_transaction_packages_count())
+            )
+        )
         result = transaction.run()
         if (
             result != dnf5_base.Transaction.TransactionRunResult_SUCCESS

--- a/nobara-updater/src/dnf.py
+++ b/nobara-updater/src/dnf.py
@@ -298,6 +298,22 @@ def _log_transaction_packages(transaction, logger: logging.Logger) -> None:
         logger.info("    (%s/%s) %s %s", index, total, action, package.get_nevra())
 
 
+def _format_nevra(nevra) -> str:
+    """libdnf5.rpm.Nevra has no useful __str__/to_string(): printing it
+    directly (e.g. via %s) yields a SWIG proxy repr like
+    "<libdnf5.rpm.Nevra; proxy of ...>" instead of the package name, which
+    makes scriptlet log lines impossible to attribute to a package. Build
+    the NEVRA string from its getters instead."""
+    epoch = nevra.get_epoch()
+    name = nevra.get_name()
+    version = nevra.get_version()
+    release = nevra.get_release()
+    arch = nevra.get_arch()
+    if epoch and epoch != "0":
+        return f"{name}-{epoch}:{version}-{release}.{arch}"
+    return f"{name}-{version}-{release}.{arch}"
+
+
 class _UpgradeTransactionCallbacks(dnf5_rpm.TransactionCallbacks):
     """Heartbeat logging for transaction.run().
 
@@ -333,12 +349,14 @@ class _UpgradeTransactionCallbacks(dnf5_rpm.TransactionCallbacks):
 
     def script_start(self, item, nevra, type) -> None:
         self.logger.info(
-            "    Running %s scriptlet for %s...", self.script_type_to_string(type), nevra
+            "    Running %s scriptlet for %s...",
+            self.script_type_to_string(type),
+            _format_nevra(nevra),
         )
 
     def script_error(self, item, nevra, type, return_code: int) -> None:
         self.logger.warning(
-            "    Scriptlet for %s exited with code %s", nevra, return_code
+            "    Scriptlet for %s exited with code %s", _format_nevra(nevra), return_code
         )
 
 

--- a/nobara-updater/src/nobara_sync.py
+++ b/nobara-updater/src/nobara_sync.py
@@ -758,12 +758,20 @@ def attempt_distro_sync() -> None:
     try:
         logger.info("Running dnf distro-sync --refresh...")
 
-        # Run dnf distro-sync with output capture
+        # Run dnf distro-sync with output capture. Force an English locale
+        # for this specific call regardless of the ambient environment: the
+        # os.environ.setdefault(...) calls above only take effect when
+        # LC_ALL/LANG aren't already set, so a non-English LC_ALL exported
+        # by the caller's shell would otherwise reach dnf here untouched
+        # and localize "Nothing to do." (e.g. "Nada que hacer." under
+        # es_ES), silently breaking the loop-prevention check below.
+        distro_sync_env = {**os.environ, "LC_ALL": "C", "LANG": "C"}
         result = subprocess.run(
             ["dnf", "distro-sync", "--refresh", "-y"],
             capture_output=True,
             text=True,
-            check=True
+            check=True,
+            env=distro_sync_env,
         )
 
         # Display the output in the status window

--- a/nobara-updater/src/nobara_sync.py
+++ b/nobara-updater/src/nobara_sync.py
@@ -770,6 +770,13 @@ def attempt_distro_sync() -> None:
         if result.stdout:
             logger.info("dnf distro-sync output:\n" + result.stdout)
 
+        # If distro-sync had nothing to do, the system is already in sync:
+        # skip module cleanup/dracut/relaunch so `repair` can't loop forever
+        # re-executing itself with the same "repair" argv on every pass.
+        if "Nothing to do" in result.stdout:
+            logger.info("distro-sync made no changes; repair complete.")
+            return
+
     except subprocess.CalledProcessError as e:
         logger.error(f"dnf distro-sync failed: {e}")
         return
@@ -818,7 +825,6 @@ def attempt_distro_sync() -> None:
 
     except subprocess.CalledProcessError as e:
         logger.error(f"An error occurred: {e}")
-        self.status_label_updates(f"Error during distro-sync: {str(e)}")
         return
 
     # Run the commands


### PR DESCRIPTION
## What this fixes

Three separate bugs in `nobara-automount` / `nobara-updater`, found while going through the open issues on this repo.

### #118 — nobara-automount hardcodes `~/Desktop`, ignoring `XDG_DESKTOP_DIR`

The auto-mount desktop-shortcut logic assumed every user's desktop folder is literally `$HOME/Desktop`. Anyone who's renamed or relocated it via `xdg-user-dirs` (a localized folder name like `Bureau`/`Schreibtisch`, or a custom location entirely) never gets a shortcut where they'd actually look for it.

Added a `resolve_desktop_dir()` helper that reads the user's real `XDG_DESKTOP_DIR` out of `~/.config/user-dirs.dirs`, falling back to `~/Desktop` when it's unset — same as before. Since this script runs as root and that config file lives inside a directory the user fully controls, the resolved path is canonicalized and required to already exist and be owned by that user before it's trusted for anything. Without that check, a crafted `XDG_DESKTOP_DIR="/etc"` or a `$HOME/../../etc`-style traversal would let a user point root-privileged `.desktop` writes/deletes at an arbitrary directory.

### #128 — `nobara-sync repair` can loop forever

`attempt_distro_sync()` unconditionally re-executed itself (`os.execv`) at the end of every run. Since the relaunched process's argv is still `repair`, it just runs the whole repair again — indefinitely, regenerating every initramfs on each pass, even once `dnf distro-sync` genuinely has nothing left to do. It now returns as soon as distro-sync reports no changes needed.

One follow-up while testing this: the "nothing to do" check was matching the literal English dnf output, which silently never fires under a non-English locale — so the fix forces an English locale for just that subprocess call rather than relying on the caller's environment.

### #126 — a major-version upgrade can look frozen for 20-40 minutes

`run_system_upgrade_transaction()` ran the rpm transaction with no progress callbacks registered, and the logger setup around it mutes the underlying libdnf5/rpm loggers — so a 10,000+ package upgrade produces *zero* output for the entire duration. That's indistinguishable from a hang, and there's a real report of a user killing what they believed was a frozen process mid-transaction, which left their system with thousands of duplicate package pairs that re-running the updater couldn't repair on its own.

Added a `TransactionCallbacks` implementation that logs a line for every package as rpm actually starts processing it, plus scriptlet start/failure lines, so there's a continuous heartbeat instead of total silence for the whole transaction.

## Testing

I don't have easy access to break my own Nobara install for this, so I tried to test each fix against something real rather than just reading the code and hoping:

- **automount fix**: unit-tested the desktop-dir resolution (including the path-traversal/ownership hardening) against five scenarios directly. Then, since the script has no actual Nobara-specific dependency (just bash/coreutils/systemd/blkid/lsblk), I built a throwaway Fedora VM with a real attached block device, a real user with a custom `XDG_DESKTOP_DIR`, and a second user with none configured, and ran the real script as root against both. The shortcut correctly lands in the custom directory for the first user and correctly falls back to `~/Desktop` for the second — full transcript below if useful.
- **repair-loop fix**: exercised the loop-guard logic directly against synthetic `dnf` output to confirm it actually breaks the cycle instead of just moving where the loop happens.
- **upgrade-progress fix**: built a real `libdnf5.base.Base`/repo_sack against this machine's actual installed packages, resolved a real (non-empty, read-only) upgrade goal, and drove the new callback class against the real `TransactionPackage`/`Nevra` objects it returned. This is what caught two things that weren't obvious from the binding's own docs: `set_callbacks()` needs a `TransactionCallbacksUniquePtr` wrapper or it raises `TypeError`, and `Nevra` has no usable string conversion (prints as a SWIG proxy repr unless you build the string from its getters yourself). Never called `.download()`/`.run()` — nothing was installed or changed on the host.

<details>
<summary>VM test transcript for the automount fix (click to expand)</summary>

```
=== detected test partition: vdb1 ===
=== UUID of test drive: 5b1d49b3-a34e-466e-8010-5aa7de4ce43f ===

########## SCENARIO 1: custom XDG_DESKTOP_DIR (testuser1 -> Schreibtisch) ##########
[nobara-automount] Created desktop icon '  98M Disk 1.desktop' (owner testuser1).
--- ls testuser1 Schreibtisch ---
-rw-r--r--. 1 testuser1 testuser1 140 Aug 15 06:31   98M Disk 1.desktop
--- ls testuser1 Desktop (should NOT exist / should be empty, proving it did not fall back) ---
ls: cannot access '/home/testuser1/Desktop/': No such file or directory
(no Desktop dir - correct, proves it used XDG_DESKTOP_DIR not hardcoded Desktop)

########## SCENARIO 3: no user-dirs.dirs -> fallback to ~/Desktop (testuser2) ##########
[nobara-automount] Created desktop icon '  98M Disk 1.desktop' (owner testuser2).
--- ls testuser2 Desktop (should have the .desktop file - fallback path) ---
-rw-r--r--. 1 testuser2 testuser2 140 Aug 15 06:31   98M Disk 1.desktop
########## DONE ##########
```

(Scenario 2 in my test script exercised `--cleanup`, but I realized partway through that cleanup only removes a shortcut for a UUID that's since been *removed* from `desktop_shortcuts.conf` — it's meant to clean up stale entries, not act as a general "unplug" hook. My test UUID was still listed, so it correctly left the shortcut alone. That's existing behavior this PR doesn't touch, my test comment was just wrong about what to expect.)

</details>

First PR to this project — let me know if I've missed a convention anywhere.
